### PR TITLE
Fix error when trying to access the feed of a 'sub-channel' when he is tied to a channel called 'videos'

### DIFF
--- a/opps/multimedias/urls.py
+++ b/opps/multimedias/urls.py
@@ -2,7 +2,7 @@
 from django.conf.urls import patterns, url
 from django.views.decorators.cache import cache_page
 
-from opps.contrib.feeds.views import ContainerFeed, ChannelFeed
+from opps.contrib.feeds.views import ContainerFeed
 
 from .views import VideoList, AudioList, AllVideoList, AllAudioList
 
@@ -10,15 +10,6 @@ from .conf import settings
 
 urlpatterns = patterns(
     '',
-    # CHANNEL FEED LIST
-    url(r'^{}/(?P<long_slug>[\w\b//-]+)/(rss|feed)$'.format(
-        settings.OPPS_MULTIMEDIAS_VIDEO_CHANNEL),
-        cache_page(settings.OPPS_CACHE_EXPIRE)(ChannelFeed()),
-        name='video_list_feed',),
-    url(r'^{}/(?P<long_slug>[\w\b//-]+)/(rss|feed)$'.format(
-        settings.OPPS_MULTIMEDIAS_AUDIO_CHANNEL),
-        cache_page(settings.OPPS_CACHE_EXPIRE)(ChannelFeed()),
-        name='audio_list_feed',),
     # CHANNEL LIST
     url(r'^{}/(?P<channel__long_slug>[\w\b//-]+)/$'.format(
         settings.OPPS_MULTIMEDIAS_VIDEO_CHANNEL),


### PR DESCRIPTION
The problem is that with the url adding 'OPPS_MULTIMEDIAS_VIDEO_CHANNEL' before the 'channel_ long_slug' regex, makes it not sent parent channel to the view. If exists a channel named 'videos' will give error because the view it will not find the sub-channel with with 'long_slug' containing the parent channel named 'videos'.
